### PR TITLE
Fix check for rails development

### DIFF
--- a/lib/simple_spark/client.rb
+++ b/lib/simple_spark/client.rb
@@ -13,7 +13,7 @@ module SimpleSpark
       fail Exceptions::InvalidConfiguration.new, 'You must provide a SparkPost API host' unless @api_host # this should never occur unless the default above is changed
       fail Exceptions::InvalidConfiguration.new, 'You must provide a SparkPost base path' unless @base_path # this should never occur unless the default above is changed
 
-      rails_development = defined?(Rails) && Rails.env.development?
+      rails_development = true & defined?(Rails) && Rails.env.development?
 
       @debug = debug.nil? ? rails_development : debug
       @session = Excon.new(@api_host, debug: @debug)

--- a/lib/simple_spark/client.rb
+++ b/lib/simple_spark/client.rb
@@ -13,7 +13,7 @@ module SimpleSpark
       fail Exceptions::InvalidConfiguration.new, 'You must provide a SparkPost API host' unless @api_host # this should never occur unless the default above is changed
       fail Exceptions::InvalidConfiguration.new, 'You must provide a SparkPost base path' unless @base_path # this should never occur unless the default above is changed
 
-      rails_development = !(defined?(Rails) && Rails.env.development?).nil?
+      rails_development = defined?(Rails) && Rails.env.development?
 
       @debug = debug.nil? ? rails_development : debug
       @session = Excon.new(@api_host, debug: @debug)


### PR DESCRIPTION
This change fix the check for Rails development. Previous expression was always returning true if `Rails` was defined (because `Rails.env.xxxx?` returns `true` or `false`, but never `nil`), and debug info was being displayed in test, production, etc.
