### PR TITLE
Check logger for a `progname=` before assigning

### DIFF
--- a/lib/simple_spark/client.rb
+++ b/lib/simple_spark/client.rb
@@ -97,7 +97,7 @@ module SimpleSpark
 
     def self.default_logger
       logger = defined?(Rails) ? Rails.logger : Logger.new(STDOUT)
-      logger.progname = 'simple_spark'
+      logger.progname = 'simple_spark' if logger.respond_to?(:progname=)
       logger
     end
 


### PR DESCRIPTION
Older loggers, like `ActiveSupport::BufferedLogger` not having `progname=` method.
