### PR TITLE
Use JSON.dump instead of to_json

### DIFF
--- a/lib/simple_spark/client.rb
+++ b/lib/simple_spark/client.rb
@@ -42,7 +42,7 @@ module SimpleSpark
 
       path = "#{@base_path}#{path}"
       params = { path: path, headers: headers }
-      params[:body] = body_values.to_json unless body_values.empty?
+      params[:body] = JSON.dump(body_values) unless body_values.empty?
       params[:query] = query_params unless query_params.empty?
 
       if @debug


### PR DESCRIPTION
In newer Rails 3.2 and above, to_json will convert HTML characters into
unicode entities.  SparkPost will choke when creating a transmission
with inlined HTML  SimpleSpark should use JSON.dump instead to so that
HTML entities aren't escaped.
