### PR TITLE
Uses JSON.generate instead of to_json on client call method

### DIFF
--- a/lib/simple_spark/client.rb
+++ b/lib/simple_spark/client.rb
@@ -42,7 +42,7 @@ module SimpleSpark
 
       path = "#{@base_path}#{path}"
       params = { path: path, headers: headers }
-      params[:body] = body_values.to_json unless body_values.empty?
+      params[:body] = JSON.generate(body_values) unless body_values.empty?
       params[:query] = query_params unless query_params.empty?
 
       if @debug


### PR DESCRIPTION
Following this PR on the official sparkpost gem: https://github.com/SparkPost/ruby-sparkpost/pull/27

I see this same error occurring with this gem, and I tested with JSON.generate and works fine.
