### PR TITLE
fix param name so suppression_list.rb search allows query_values

### DIFF
--- a/lib/simple_spark/endpoints/suppression_list.rb
+++ b/lib/simple_spark/endpoints/suppression_list.rb
@@ -17,7 +17,7 @@ module SimpleSpark
       # @return [Array] a list of sample Suppression Status hash objects
       # @note See: https://developers.sparkpost.com/api/suppression-list#suppression-list-search-get
       def search(params = {})
-        @client.call(method: :get, path: 'suppression-list', query_params: params)
+        @client.call(method: :get, path: 'suppression-list', query_values: params)
       end
 
       # Insert or Update List Entries


### PR DESCRIPTION
any query like ```simple_spark.suppression_list.search({"page"=> 1, "per_page"=> 10})``` does not work, but with this change it will. Typo in code is fixed